### PR TITLE
更新：step14 Hugging Face Spaces Docker 部署

### DIFF
--- a/backend.md
+++ b/backend.md
@@ -296,7 +296,8 @@ Rails 7 起，刪除功能有兩個和以往不同的寫法要注意：
 	- 資料庫請使用 [Neon](https://neon.tech/) 或 [Supabase](https://supabase.com/) 的免費 PostgreSQL（Render 免費方案的 PostgreSQL 只能使用 30 天，不建議使用）
 		- 在 Render 上以 `DATABASE_URL` 環境變數設定連線字串
 		- 藉此理解 app 和資料庫分開託管、以環境變數注入設定的實務做法
-- 【選項】想順便學 Docker 的人，可以改部署到 [Hugging Face Spaces](https://huggingface.co/spaces)（Docker Space）
+- 【選項】想順便學 Docker 的人，可以改部署到 [Hugging Face Spaces](https://huggingface.co/spaces)（Docker Space ）*2026/8更新：需付費才可以使用
+Docker Space* 
 	- 直接使用 `rails new` 產生的 `Dockerfile`，但 HF 要求 app 聽 port 7860
 	- 部署方式是把程式碼 push 到 HF 提供的 git remote
 	- 免費方案 48 小時沒有流量會休眠，喚醒時有冷啟動延遲


### PR DESCRIPTION
## 修改內容

更新步驟14 的 Hugging Face Spaces Docker 部署選項說明，補充 2026/8 發現 Docker Space 已改為付費方案才能使用的資訊。

## 修改原因

Hugging Face 於 2026 年 將免費方案的 Docker Space 移至付費牆後（需 PRO 訂閱 $9/月），原教材中「免費方案」的描述已不適用。

參考來源：https://discuss.huggingface.co/t/docker-sdk-now-marked-as-paid-when-creating-a-new-space/177580

## 變更檔案

- `backend.md`：步驟14 Docker 部署選項加註「2026/8更新：需付費才可以使用 Docker Space」